### PR TITLE
[CAB-9196]: Drop primait/phoenix_pubsub_redis or publish it to hex.pm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,39 @@
+name: CD
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          elixir-version: '1.17'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: setup hex
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+      - name: Get deps
+        run: mix deps.get
+      - name: Get version
+        run: |
+          VERSION=$(grep -m1 version mix.exs | cut -d'"' -f2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Check version
+        if: ${{ github.event.release.tag_name != env.VERSION }}
+        run: |
+          echo "Github ref tag [${{ github.event.release.tag_name }}] is different from mix.exs version [${{ env.VERSION }}]"
+          exit 1
+      - name: Login to hex.pm
+        run: |
+          mix hex.config api_key "$HEX_AUTH_KEY"
+        env:
+          HEX_AUTH_KEY: ${{ secrets.HEX_AUTH_KEY }}
+      - name: Publish
+        run: mix hex.publish --yes

--- a/.github/workflows/retire.yml
+++ b/.github/workflows/retire.yml
@@ -1,0 +1,44 @@
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Retire reason
+        required: true
+        default: invalid
+        type: choice
+        options:
+          - renamed
+          - deprecated
+          - security
+          - invalid
+          - other
+      message:
+        description: Retire message
+        required: true
+        default: Version has a breaking bug
+        type: string
+      version:
+        description: Version to retire
+        required: true
+        default: x.y.z
+        type: string
+
+jobs:
+  retire:
+    runs-on: ubuntu-latest
+    env:
+      MESSAGE: ${{ inputs.message }}
+      REASON: ${{ inputs.reason }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: '26'
+          elixir-version: '1.17'
+      - run: echo "Attempting to retire version $VERSION"
+      - run: mix hex.config api_key "$HEX_AUTH_KEY"
+        env:
+          HEX_AUTH_KEY: ${{ secrets.HEX_AUTH_KEY }}
+      - run: mix hex.user whoami
+      - run: mix hex.retire csv_schema "$VERSION" "$REASON" --message "$MESSAGE"

--- a/README.md
+++ b/README.md
@@ -1,70 +1,12 @@
-## Phoenix.PubSub.Redis
+# Why this fork?
 
-> A Redis PubSub adapter for the Phoenix framework
+This repo is a fork of https://github.com/phoenixframework/phoenix_pubsub_redis.
 
-See the [docs](https://hexdocs.pm/phoenix_pubsub_redis/) for more information.
-
-## Usage
-
-To use Redis as your PubSub adapter, simply add it to your deps and Application's Supervisor tree:
+To avoid conflicts with the original package, we published this one on hex.pm under the name `prima_phoenix_pubsub_redis`, so install it like:
 
 ```elixir
-# mix.exs
-defp deps do
-  [{:phoenix_pubsub_redis, "~> 3.0.0"}],
-end
-
-# application.ex
-children = [
-  # ...,
-  {Phoenix.PubSub,
-   adapter: Phoenix.PubSub.Redis,
-   host: "192.168.1.100",
-   node_name: System.get_env("NODE")}
+{:prima_phoenix_pubsub_redis, "~> 3.0.2"}
 ```
 
-Config Options
-
-Option                  | Description                                                               | Default        |
-:-----------------------| :------------------------------------------------------------------------ | :------------- |
-`:name`                 | The required name to register the PubSub processes, ie: `MyApp.PubSub`    |                |
-`:node_name`            | The required and unique name of the node, ie: `System.get_env("NODE")`    |                |
-`:url`                  | The redis-server URL, ie: `redis://username:password@host:port`           |                |
-`:host`                 | The redis-server host IP                                                  | `"127.0.0.1"`  |
-`:port`                 | The redis-server port                                                     | `6379`         |
-`:password`             | The redis-server password                                                 | `""`           |
-`:compression_level`    | Compression level applied to serialized terms (`0` - none, `9` - highest) | `0`            |
-`:socket_opts`          | The redis-server network layer options                                    | `[]`           |
-
-And also add `:phoenix_pubsub_redis` to your list of applications:
-
-```elixir
-# mix.exs
-def application do
-  [mod: {MyApp, []},
-   applications: [..., :phoenix, :phoenix_pubsub_redis]]
-end
-```
-
-## License
-
-Copyright (c) 2014 Chris McCord
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The original repo has a bug that doesn't allow us to specify a username for the redis authentication.
+We opened a [PR with the fix](https://github.com/phoenixframework/phoenix_pubsub_redis/pull/69), but it's hasn't been merged yet, so, in the meantime, we had to fork.

--- a/mix.exs
+++ b/mix.exs
@@ -41,8 +41,8 @@ defmodule PhoenixPubsubRedis.Mixfile do
 
   defp package do
     [
-      organization: "prima",
       licenses: ["Apache-2.0"],
+      maintainers: ["prima-assicurazioni"],
       links: %{"GitHub" => @source_url}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule PhoenixPubsubRedis.Mixfile do
 
   defp package do
     [
+      name: "prima_phoenix_pubsub_redis",
       licenses: ["Apache-2.0"],
       maintainers: ["prima-assicurazioni"],
       links: %{"GitHub" => @source_url}

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule PhoenixPubsubRedis.Mixfile do
   use Mix.Project
 
   @version "3.0.2"
-  @source_url "https://github.com/phoenixframework/phoenix_pubsub_redis"
+  @source_url "https://github.com/primait/phoenix_pubsub_redis"
 
   def project do
     [
@@ -13,12 +13,8 @@ defmodule PhoenixPubsubRedis.Mixfile do
       start_permanent: Mix.env() == :prod,
       package: package(),
       deps: deps(),
-      description: "The Redis PubSub adapter for the Phoenix framework",
-      docs: [
-        source_ref: "v#{@version}",
-        source_url: @source_url,
-        main: "Phoenix.PubSub.Redis"
-      ]
+      description: "A fork of the Redis PubSub adapter for the Phoenix framework",
+      docs: docs()
     ]
   end
 
@@ -45,9 +41,18 @@ defmodule PhoenixPubsubRedis.Mixfile do
 
   defp package do
     [
-      maintainers: ["Chris McCord"],
-      licenses: ["MIT"],
-      links: %{GitHub: @source_url}
+      organization: "prima",
+      licenses: ["Apache-2.0"],
+      links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp docs do
+    [
+      main: "readme",
+      source_ref: @version,
+      source_url: @source_url,
+      extras: ["README.md"]
     ]
   end
 end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/CAB-9196

We added the github actions to publish to the public hexpm registry.
We need to set the secret HEX_AUTH_KEY, but first let's wait for confirmation from the SRE or the platform team.
